### PR TITLE
"Cannot read property 'nativeElement' of undefined" bugfix

### DIFF
--- a/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
+++ b/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
 import Typed, {TypedOptions} from 'typed.js';
 
 @Component({
@@ -43,14 +43,12 @@ export class NgxTypedJsComponent implements OnInit, AfterViewInit {
   private typed: Typed;
   @ViewChild('wrapper', { static: true }) private content;
 
-  ngOnInit() {
+  ngAfterViewInit(): void {
     this.typed = new Typed(
       this.content.nativeElement.querySelector('.typing'),
       this.options,
     );
-  }
 
-  ngAfterViewInit(): void {
     if (this.showCursor !== false) {
       this.updateCursorStyle();
     }


### PR DESCRIPTION
I tried to use this package with Angular v9.0.3, but the content in the ngOnInit method was undefined, because it is trying to get the value from html before rendering completely. The method works when it is moved inside ngAfterViewInit.