### PR TITLE
Added a check for typed property in ngOnChanges for NgxTypedJsComponent

### DIFF
--- a/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
+++ b/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
@@ -130,7 +130,9 @@ export class NgxTypedJsComponent implements AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.typed.destroy();
-    this.ngAfterViewInit();
+    if (this.typed) {
+      this.typed.destroy();
+      this.ngAfterViewInit();
+    }
   }
 }


### PR DESCRIPTION
This merge request is a fix for the issue **TypeError: Cannot read property 'destroy' of undefined #21**

![Capture](https://user-images.githubusercontent.com/44159951/119149873-5a0aff00-ba67-11eb-981f-7a178eab6149.JPG)
