### PR TITLE
adding cursorChar to typed.js opts

### DIFF
--- a/projects/ngx-typed-js/package.json
+++ b/projects/ngx-typed-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-typed-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "dependencies": {
     "typed.js": "^2.0.12"
   },

--- a/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
+++ b/projects/ngx-typed-js/src/lib/ngx-typed-js.component.ts
@@ -86,6 +86,7 @@ export class NgxTypedJsComponent implements AfterViewInit, OnChanges {
       stringsElement: this.stringsElement,
       typeSpeed: this.typeSpeed,
       startDelay: this.startDelay,
+      cursorChar: this.cursorChar,
       backSpeed: this.backSpeed,
       smartBackspace: this.smartBackspace,
       shuffle: this.shuffle,


### PR DESCRIPTION
`cursorChar` wasn't been passed to `typed.js` library so when some user tried to change the `@Input() public cursorChar?: string;` wasn't changing anything.